### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    #@items = Item.all
+    @items = Item.all.order(id: "DESC")
   end
   def new
     @item = Item.new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.all.order(id: "DESC")
+    @items = Item.includes(:user).order("created_at DESC")
   end
   def new
     @item = Item.new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -154,30 +154,6 @@
       <% end %>
      <% else %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,4 +1,4 @@
-<<%= render "devise/shared/header" %>
+<%= render "devise/shared/header" %>
 <div class='main'>
 
   <%# 画面上部の「人生を変えるフリマアプリ」帯部分 %>
@@ -127,19 +127,41 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+     <% if @items.present? %>
+      <% @items.each do |item| %>
+        <li class='list'>      
+        <div class='item-img-content'>
+        <%= link_to image_tag(item.image, class: "item-img"),root_path %>
+        <% if item.present? %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+        <% end %>
+       </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+           <%= item.title %>
+          </h3>
+          <div class='item-price'>
+           <span><%= item.price %>円<br><%= item.postage.name %></span>
+           <div class='star-btn'>
+            <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+       </li>
+      <% end %>
+     <% else %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
-
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
-
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -155,28 +177,6 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <%#<% if @items.present? %>
-      <%#<li class='list'>      
-        <%#<% @items.each do |item| %>
-        <%#<%= link_to image_tag(item.image, class: "item-img"),root_path %>
-        <%#<div class='item-info'>
-          <%#<h3 class='item-name'>
-           <%# <%= item.title %>
-          <%#</h3>
-          <%#<div class='item-price'>
-           <%# <span><%= item.price %><%#<br>(税込み)</span>
-           <%# <div class='star-btn'>
-            <%#  <%= image_tag "star.png", class:"star-icon" %>
-              <%#<span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      <%#</li>
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%#<% else %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -194,9 +194,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%#<% end %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
#what
商品一覧表示機能の実装
#why
投稿された商品を一覧表示させるため。
投稿が一つもない場合は見本を表示している。

##以下、実装内容の動画
 -商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/80c3c916c67d7631a3570ba4275e4f13
 -商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/5c70731bceee1c8a8f21e96b6d77f343